### PR TITLE
Update VMX.h

### DIFF
--- a/Part 4 - Address Translation Using Extended Page Table (EPT)/MyHypervisorDriver/MyHypervisorDriver/VMX.h
+++ b/Part 4 - Address Translation Using Extended Page Table (EPT)/MyHypervisorDriver/MyHypervisorDriver/VMX.h
@@ -20,7 +20,7 @@ extern int                     g_ProcessorCounts;
 BOOLEAN
 IsVmxSupported();
 
-VOID
+BOOLEAN
 InitializeVmx();
 
 VOID


### PR DESCRIPTION
Change the return type of `InitializxeVmx()` to `BOOLEAN`. This is needed to compile the driver as 

https://github.com/SinaKarvandi/Hypervisor-From-Scratch/blob/3eb8dace4a64c3ec51a4c6c09077e53664b38f67/Part%203%20-%20Setting%20up%20Our%20First%20Virtual%20Machine/MyHypervisorDriver/MyHypervisorDriver/Driver.c#L69