### PR TITLE
fix: VMXON and VMCS allocated memory address should be stored based in the address passed in the argument.

### DIFF
--- a/Part 4 - Address Translation Using Extended Page Table (EPT)/MyHypervisorDriver/MyHypervisorDriver/Memory.c
+++ b/Part 4 - Address Translation Using Extended Page Table (EPT)/MyHypervisorDriver/MyHypervisorDriver/Memory.c
@@ -72,7 +72,7 @@ AllocateVmxonRegion(IN VIRTUAL_MACHINE_STATE * GuestState)
         return FALSE;
     }
 
-    g_GuestState->VmxonRegion = AlignedPhysicalBuffer;
+    GuestState->VmxonRegion = AlignedPhysicalBuffer;
 
     return TRUE;
 }
@@ -131,7 +131,7 @@ AllocateVmcsRegion(IN VIRTUAL_MACHINE_STATE * GuestState)
         return FALSE;
     }
 
-    g_GuestState->VmcsRegion = AlignedPhysicalBuffer;
+    GuestState->VmcsRegion = AlignedPhysicalBuffer;
 
     return TRUE;
 }


### PR DESCRIPTION


```c
VIRTUAL_MACHINE_STATE * g_GuestState;
```

g_GuestState is accessed as an array if we write into g_GuestState we only write into the first element, the rest remain zeroed which cause the freeing routine to free a null pointer which cause a BSOD.