### PR TITLE
Fix: choosing compiler optimizations to have the same epilogue for the LaunchVm function as in the tutorial

### DIFF
--- a/Part 5 - Setting up VMCS & Running Guest Code/MyHypervisorDriver/MyHypervisorDriver/VMX.c
+++ b/Part 5 - Setting up VMCS & Running Guest Code/MyHypervisorDriver/MyHypervisorDriver/VMX.c
@@ -44,6 +44,8 @@ InitiateVmx()
     }
 }
 
+#pragma optimize("gy", on)
+
 VOID
 LaunchVm(int ProcessorID, PEPTP EPTP)
 {
@@ -131,6 +133,8 @@ ErrorReturn:
     DbgPrint("[*] Fail to setup VMCS !\n");
     return FALSE;
 }
+
+#pragma optimize("", on)
 
 VOID
 TerminateVmx()


### PR DESCRIPTION
I tried to solve the problem that when compiling the part 5 project, the same epilogue is not generated by the compiler as the tutorial. Instead of adapting the assembly code to new epilogue. I noticed that specific compiler optimizations generate the same epilogues as in the tutorial which is convenient. 